### PR TITLE
Do not use Azure SDK nuget feed

### DIFF
--- a/gen/generate_local.ps1
+++ b/gen/generate_local.ps1
@@ -11,13 +11,13 @@ param()
 $PSNativeCommandUseErrorActionPreference = $true
 $ErrorActionPreference = 'Stop'
 
-# The version here must be aligned with version of the NuGet package.
+# The version here must be aligned with the version of the NuGet package.
 # Steps for updating the version:
 # 1. Update the version in the csproj
 # 2. Upload the package to our Azure Artifacts NuGet feed
 # The autorest csharp package is not released to nuget.org and the NuGet
 # feed of the Azure SDK team causes issues during package restore. Hence,
-# we upload the package to our NuGet feed.
+# we upload the package to our own NuGet feed.
 $autoRestCSharpVersion = "3.0.0-beta.20241108.1"
 
 $settings = Get-Content -Raw -Path "$PSScriptRoot/config.json" | ConvertFrom-Json

--- a/gen/generate_local.ps1
+++ b/gen/generate_local.ps1
@@ -11,7 +11,13 @@ param()
 $PSNativeCommandUseErrorActionPreference = $true
 $ErrorActionPreference = 'Stop'
 
-# Update the version in the csproj when changing this
+# The version here must be aligned with version of the NuGet package.
+# Steps for updating the version:
+# 1. Update the version in the csproj
+# 2. Upload the package to our Azure Artifacts NuGet feed
+# The autorest csharp package is not released to nuget.org and the NuGet
+# feed of the Azure SDK team causes issues during package restore. Hence,
+# we upload the package to our NuGet feed.
 $autoRestCSharpVersion = "3.0.0-beta.20241108.1"
 
 $settings = Get-Content -Raw -Path "$PSScriptRoot/config.json" | ConvertFrom-Json

--- a/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
+++ b/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
@@ -9,6 +9,7 @@
 
   <PropertyGroup>
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
+    
     <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 

--- a/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
+++ b/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
@@ -9,8 +9,6 @@
 
   <PropertyGroup>
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
-    
-    <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes the reference to the NuGet feed of the Azure SDK team as the feed causes issues during the package restore.