### PR TITLE
Consume OpenIddict 7 client-assertion preview (ClientRuntime)

### DIFF
--- a/src/Eryph.IdentityClient.Commands/Eryph.IdentityClient.Commands.csproj
+++ b/src/Eryph.IdentityClient.Commands/Eryph.IdentityClient.Commands.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.9.1-PullRequest0066.2" />
+    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.10.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Eryph.IdentityClient.Commands/Eryph.IdentityClient.Commands.csproj
+++ b/src/Eryph.IdentityClient.Commands/Eryph.IdentityClient.Commands.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.9.0" />
+    <PackageReference Include="Eryph.ClientRuntime.Powershell" Version="0.9.1-PullRequest0066.2" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
+++ b/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.9.0" />
+    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.9.1-PullRequest0066.2" />
     <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20241108.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
+++ b/src/Eryph.IdentityClient/Eryph.IdentityClient.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.9.1-PullRequest0066.2" />
+    <PackageReference Include="Eryph.ClientRuntime.Authentication" Version="0.10.0" />
     <PackageReference Include="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20241108.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumps `Eryph.ClientRuntime.Authentication` and `Eryph.ClientRuntime.Powershell` to the preview build `0.9.1-PullRequest0066.2` (dbosoft feed), carrying the new discovery-based client-assertion audience negotiation up the chain:

dotnet-identitymodel#42 → dotnet-clientruntime#66 → here.

Lets identity-client auth be tested end-to-end against an eryph server upgraded to OpenIddict 7. No code changes — the ClientRuntime public API is unchanged.

Preview pins — to be re-pinned to the released versions once the chain merges and ships.